### PR TITLE
Store the connectivity manager as class variable

### DIFF
--- a/src/androidMain/kotlin/com/github/ln_12/library/ConnectivityStatus.kt
+++ b/src/androidMain/kotlin/com/github/ln_12/library/ConnectivityStatus.kt
@@ -54,9 +54,9 @@ actual class ConnectivityStatus(private val context: Context) {
             }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 // API 24 and above
-                connectivityManager!!.registerDefaultNetworkCallback(networkCallback)
+                connectivityManager?.registerDefaultNetworkCallback(networkCallback)
 
-                val currentNetwork = connectivityManager!!.activeNetwork
+                val currentNetwork = connectivityManager?.activeNetwork
 
                 if(currentNetwork == null) {
                     isNetworkConnected.value = false
@@ -73,10 +73,10 @@ actual class ConnectivityStatus(private val context: Context) {
                     }
                 }.build()
 
-                connectivityManager!!.registerNetworkCallback(networkRequest, networkCallback)
+                connectivityManager?.registerNetworkCallback(networkRequest, networkCallback)
 
                 @Suppress("DEPRECATION")
-                val currentNetwork = connectivityManager!!.activeNetworkInfo
+                val currentNetwork = connectivityManager?.activeNetworkInfo
 
                 @Suppress("DEPRECATION")
                 if(currentNetwork == null || (

--- a/src/androidMain/kotlin/com/github/ln_12/library/ConnectivityStatus.kt
+++ b/src/androidMain/kotlin/com/github/ln_12/library/ConnectivityStatus.kt
@@ -16,7 +16,7 @@ import kotlinx.coroutines.withContext
 actual class ConnectivityStatus(private val context: Context) {
     actual val isNetworkConnected = MutableStateFlow(false)
 
-    private val connectivityManager: ConnectivityManager? = null
+    private var connectivityManager: ConnectivityManager? = null
     private val networkCallback = object : ConnectivityManager.NetworkCallback() {
         override fun onAvailable(network: Network) {
             Log.d("Connectivity status", "Network available")
@@ -49,13 +49,14 @@ actual class ConnectivityStatus(private val context: Context) {
 
     actual fun start() {
         try {
-            val connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
-
+            if (connectivityManager == null) {
+                connectivityManager = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
+            }
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 // API 24 and above
-                connectivityManager.registerDefaultNetworkCallback(networkCallback)
+                connectivityManager!!.registerDefaultNetworkCallback(networkCallback)
 
-                val currentNetwork = connectivityManager.activeNetwork
+                val currentNetwork = connectivityManager!!.activeNetwork
 
                 if(currentNetwork == null) {
                     isNetworkConnected.value = false
@@ -72,10 +73,10 @@ actual class ConnectivityStatus(private val context: Context) {
                     }
                 }.build()
 
-                connectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+                connectivityManager!!.registerNetworkCallback(networkRequest, networkCallback)
 
                 @Suppress("DEPRECATION")
-                val currentNetwork = connectivityManager.activeNetworkInfo
+                val currentNetwork = connectivityManager!!.activeNetworkInfo
 
                 @Suppress("DEPRECATION")
                 if(currentNetwork == null || (


### PR DESCRIPTION
This fixes #3 
It is now possible to stop the monitoring by unregistering the network callback.